### PR TITLE
Update the depth & stencils chapter for GLFW 3.0

### DIFF
--- a/content/depthstencils.md
+++ b/content/depthstencils.md
@@ -3,11 +3,6 @@ Extra buffers
 
 Up until now there is only one type of output buffer you've made use of, the color buffer. This chapter will discuss two additional types, the *depth buffer* and the *stencil buffer*. For each of these a problem will be presented and subsequently solved with that specific buffer.
 
-The depth and stencil buffers are optional, so you need to make sure that they're created before you try using them. SFML and SDL users can continue to the next section, but GLFW users will have to make a slight modification to their program.
-
-	glfwOpenWindow( 800, 600, 0, 0, 0, 0, 24, 8, GLFW_WINDOW );
-
-The `glfwOpenWindow` call above creates a 24 bit depth buffer and an 8 bit stencil buffer. These numbers determine the accuracy of the buffers.
 
 Preparations
 ========


### PR DESCRIPTION
Hi, the chapter _Context Creation_ was updated for GLFW 3.0, but the code at the beginning of _Depth and Stencils_ is still for the old version.

GLFW 3.0 uses `glfwWindowHint()` to set depth and stencil bits, but the default value for depth bits is 24, and 8 for the stencil. So I think the whole paragraph is unnecessary now.

http://www.glfw.org/docs/latest/window.html#window_hints_values
