### PR TITLE
Typo fix in context.md

### DIFF
--- a/content/context.md
+++ b/content/context.md
@@ -117,7 +117,7 @@ When running this, you'll notice that the application instantly closes after cre
 		}
 	}
 
-When something happens to your window, an event is posted to the event queue. There are is a wide variety of events, including window size changes, mouse movement and key presses. It's up to you to decide which events require additional action, but there is at least one that needs to be handled to make your application run well.
+When something happens to your window, an event is posted to the event queue. There is a wide variety of events, including window size changes, mouse movement and key presses. It's up to you to decide which events require additional action, but there is at least one that needs to be handled to make your application run well.
 
 	switch (windowEvent.type)
 	{


### PR DESCRIPTION
There is a very minor typo in context.md that I found as I was learning OpenGL.
![screenshot from 2013-12-21 11 03 04](https://f.cloud.github.com/assets/5475372/1797057/3e9bd038-6aa5-11e3-8cf9-6ac43cbe3bc0.png)
