### PR TITLE
SDL corrections in content creation chapter

### DIFF
--- a/content/context.md
+++ b/content/context.md
@@ -210,7 +210,7 @@ The `SDL_Init` function takes a bitfield with the modules to load. The video mod
 
 	SDL_Window* window = SDL_CreateWindow("OpenGL", 100, 100, 800, 600, SDL_WINDOW_OPENGL);
 
-The first argument specifies the title of the window, the next two the X and Y position and the two after those the width and height. If you don't care about position, you can specifiy `SDL_WINDOWPOS_UNEFINED` or `SDL_WINDOWPOS_CENTERED` for second and third argument. The final parameter specifies window properties like:
+The first argument specifies the title of the window, the next two are the X and Y position and the two after those are the width and height. If you don't care about position, you can specifiy `SDL_WINDOWPOS_UNEFINED` or `SDL_WINDOWPOS_CENTERED` for second and third argument. The final parameter specifies window properties like:
 
 - *SDL_WINDOW_OPENGL* - Create a window ready for OpenGL.
 - *SDL_WINDOW_RESIZABLE* - Create a resizable window.


### PR DESCRIPTION
SDL doesn't require full `main()` prototype since SDL 2. see http://wiki.libsdl.org/MigrationGuide > _Some general thruths_

Then I couldn't help but mention that you don't have to specify position for window, you can let OS' WM choose or place it in the center.

Also you were missing two `are`s in the same paragraph.

What's left is that afaik you don't need to link against SDL2main, because I don't and everything works. I can't check on windows though.
