### PR TITLE
Changed #nav `z-index` so that it's always on top

### DIFF
--- a/media/mobile.css
+++ b/media/mobile.css
@@ -26,6 +26,7 @@ code, .MathJax_Display, .livedemo_wrap {
   right: 0;
   width: auto;
   padding: 1em;
+  z-index: 10;
 }
 
 /* Menu button */


### PR DESCRIPTION
The "example outputs" where stacked higher and occluded the menu
(currently only a 2 is needed, but a 10 is more future-proof)
