### PR TITLE
Added forward compatibility flag for GLFW

### DIFF
--- a/content/articles-en/context.md
+++ b/content/articles-en/context.md
@@ -311,6 +311,7 @@ The next thing to do is creating and configuring the window. Before calling `glf
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 
 	glfwWindowHint(GLFW_RESIZABLE, GL_FALSE);
 


### PR DESCRIPTION
This is required for context creation to succeed on OS X and will do no harm on other platforms.
