### PR TITLE
Changed "Gluint" to "GLuint" in "One more thing" Section

### DIFF
--- a/content/articles-en/context.md
+++ b/content/articles-en/context.md
@@ -363,7 +363,7 @@ Your program needs to check which functions are available at runtime and link wi
 	GENBUFFERS glGenBuffers = (GENBUFFERS)NSGLGetProcAddress("glGenBuffers");
 
 	// Call function as normal
-	Gluint buffer;
+	GLuint buffer;
 	glGenBuffers(1, &buffer);
 
 Let me begin by asserting that it is perfectly normal to be scared by this snippet of code. You may not be familiar with the concept of function pointers yet, but at least try to roughly understand what is happening here. You can imagine that going through this process of defining prototypes and finding addresses of functions is very tedious and in the end nothing more than a complete waste of time.


### PR DESCRIPTION
My compiler told me "error: ‘Gluint’ was not declared in this scope", and it took me forever to realize, that the "L" in "GLuint" is supposed to be capitalized. I am running Arch Linux and use the gcc to compile my code.