### PR TITLE
Fixes code formatting in Sobel operator fragment shader

### DIFF
--- a/content/articles-en/framebuffers.md
+++ b/content/articles-en/framebuffers.md
@@ -244,8 +244,8 @@ The fragment shader looks like this:
 	vec4 topRight    = texture(texFramebuffer, vec2(Texcoord.x + 1.0 / 300.0, Texcoord.y + 1.0 / 200.0));
 	vec4 bottomLeft  = texture(texFramebuffer, vec2(Texcoord.x - 1.0 / 300.0, Texcoord.y - 1.0 / 200.0));
 	vec4 bottomRight = texture(texFramebuffer, vec2(Texcoord.x + 1.0 / 300.0, Texcoord.y - 1.0 / 200.0));
-	vec4 sx = -topLeft - 2 * left - bottomLeft + topRight     + 2 * right  + bottomRight;
-	vec4 sy = -topLeft - 2 * top  - topRight   + bottomLeft   + 2 * bottom + bottomRight;
+	vec4 sx = -topLeft - 2 * left - bottomLeft + topRight   + 2 * right  + bottomRight;
+	vec4 sy = -topLeft - 2 * top  - topRight   + bottomLeft + 2 * bottom + bottomRight;
 	vec4 sobel = sqrt(sx * sx + sy * sy);
 	outColor = sobel;
 


### PR DESCRIPTION
I found and fixed a minor code formatting issue in chapter 6.