### PR TITLE
Require ES 3.2 for #version 150

### DIFF
--- a/content/code/c8_exercise_1.txt
+++ b/content/code/c8_exercise_1.txt
@@ -58,6 +58,8 @@ int main()
     sf::ContextSettings settings;
     settings.depthBits = 24;
     settings.stencilBits = 8;
+    settings.majorVersion = 3;
+    settings.minorVersion = 2;
 
     sf::Window window(sf::VideoMode(800, 800, 32), "Transform Feedback", sf::Style::Titlebar | sf::Style::Close, settings);
 


### PR DESCRIPTION
This is needed at least on Linux with Mesa and the Intel driver, otherwise shader compilation will fail, saying `#version 150` is not supported.