### PR TITLE
Triangles in chapter 2, exercise 4 are now wound in anti-clockwise fa…

### DIFF
--- a/content/code/c2_exercise_4.txt
+++ b/content/code/c2_exercise_4.txt
@@ -64,8 +64,8 @@ int main()
     glGenBuffers(1, &ebo);
 
     GLuint elements[] = {
-        0, 1, 2,
-        2, 3, 0
+        2, 1, 0,  // Anti-clockwise winding
+        0, 3, 2,
     };
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);

--- a/content/code/c2_triangle_elements.txt
+++ b/content/code/c2_triangle_elements.txt
@@ -65,8 +65,8 @@ int main()
     glGenBuffers(1, &ebo);
 
     GLuint elements[] = {
-        0, 1, 2,
-        2, 3, 0
+        2, 1, 0,  // Anti-clockwise winding
+        0, 3, 2,
     };
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
@@ -98,6 +98,8 @@ int main()
     GLint colAttrib = glGetAttribLocation(shaderProgram, "color");
     glEnableVertexAttribArray(colAttrib);
     glVertexAttribPointer(colAttrib, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(GLfloat), (void*)(2 * sizeof(GLfloat)));
+
+    //glEnable (GL_CULL_FACE);
 
     bool running = true;
     while (running)


### PR DESCRIPTION
Hi there,

Thanks very much for the OpenGL tutorial!  The last time I touched OpenGL it was version 1.2!

I had some trouble continuing on from the tutorial with textures being flipped.  It turned out that I had the incorrect winding for the triangles.  I remembered anti-clockwise from v1.2 but assumed that it had changed when I saw clockwise in the tutorial.

I can go through and change the rest of the example code and articles if it helps.

Thanks again for a superb tutorial!
